### PR TITLE
feat: allow for additional params on conditionalPut

### DIFF
--- a/getFileBody.js
+++ b/getFileBody.js
@@ -1,8 +1,32 @@
 'use strict';
 
 var Q = require('q'),
+    _ = require('underscore'),
     AWS = require('aws-sdk'),
-    s3 = new AWS.S3();
+    s3 = new AWS.S3(),
+    RETAINED_KEYS;
+
+RETAINED_KEYS = [
+   'Bucket',
+   'Key',
+   'IfMatch',
+   'IfModifiedSince',
+   'IfNoneMatch',
+   'IfUnmodifiedSince',
+   'PartNumber',
+   'Range',
+   'RequestPayer',
+   'ResponseCacheControl',
+   'ResponseContentDisposition',
+   'ResponseContentEncoding',
+   'ResponseContentLanguage',
+   'ResponseContentType',
+   'ResponseExpires',
+   'SSECustomerAlgorithm',
+   'SSECustomerKey',
+   'SSECustomerKeyMD5',
+   'VersionId',
+];
 
 /**
  * Returns false if a file did not exist, otherwise returns the string or
@@ -13,7 +37,7 @@ var Q = require('q'),
  * not exist
  */
 module.exports = function getExistingFileBody(params) {
-   return Q.ninvoke(s3, 'getObject', params)
+   return Q.ninvoke(s3, 'getObject', _.pick(params, RETAINED_KEYS))
       .then(function(resp) {
          return resp.Body;
       })


### PR DESCRIPTION
When you add params like `ContentType` to your conditionalPut, those
were being sent to the GetObject call as well. Now we filter the params
sent to the GetObject call so that no unsupported params are sent to it.